### PR TITLE
Docker image for `liquigraph-ci`.

### DIFF
--- a/liquigraph-ci/Dockerfile
+++ b/liquigraph-ci/Dockerfile
@@ -5,6 +5,9 @@ ENV CHANGELOG="changelog.xml"
 ENV NEO4J_JDBC_URL="jdbc:neo4j:neo4j://localhost:7687/"
 ENV NEO4J_USER="neo4j"
 ENV NEO4J_PASSWORD=""
+ENV WAIT_FOR_URL="localhost:7474"
+ENV WAIT_RETRIES=60
+ENV WAIT_BETWEEN=1
 
 WORKDIR /usr
 RUN wget --no-check-certificate -q \
@@ -17,8 +20,11 @@ RUN diff -w sum liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz.md5
 RUN tar xzf liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz
 ENV PATH=$PATH:/usr/liquigraph-cli
 
+ADD ./wait.sh ./wait.sh
+
 WORKDIR /
-ENTRYPOINT liquigraph.sh                    \
+ENTRYPOINT /usr/wait.sh "$WAIT_FOR_URL" $WAIT_RETRIES $WAIT_BETWEEN \
+           liquigraph.sh                    \
            --changelog    "$CHANGELOG"      \
            --graph-db-uri "$NEO4J_JDBC_URL" \
            --username     "$NEO4J_USER"     \

--- a/liquigraph-ci/Dockerfile
+++ b/liquigraph-ci/Dockerfile
@@ -1,0 +1,25 @@
+FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+ARG LIQUIGRAPH_VERSION=4.0.2
+
+ENV CHANGELOG="changelog.xml"
+ENV NEO4J_JDBC_URL="jdbc:neo4j:neo4j://localhost:7687/"
+ENV NEO4J_USER="neo4j"
+ENV NEO4J_PASSWORD=""
+
+WORKDIR /usr
+RUN wget --no-check-certificate -q \
+    https://repo1.maven.org/maven2/org/liquigraph/liquigraph-cli/${LIQUIGRAPH_VERSION}/liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz.md5
+RUN wget --no-check-certificate -q \
+    https://repo1.maven.org/maven2/org/liquigraph/liquigraph-cli/${LIQUIGRAPH_VERSION}/liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz
+RUN md5sum liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz | cut -d " " -f1 > sum
+RUN diff -w sum liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz.md5
+
+RUN tar xzf liquigraph-cli-${LIQUIGRAPH_VERSION}-bin.tar.gz
+ENV PATH=$PATH:/usr/liquigraph-cli
+
+WORKDIR /
+ENTRYPOINT liquigraph.sh                    \
+           --changelog    "$CHANGELOG"      \
+           --graph-db-uri "$NEO4J_JDBC_URL" \
+           --username     "$NEO4J_USER"     \
+           --password     "$NEO4J_PASSWORD"

--- a/liquigraph-ci/README.md
+++ b/liquigraph-ci/README.md
@@ -1,0 +1,11 @@
+# Docker image for `liquigraph-ci`
+
+See section [Highway to shell](https://www.liquigraph.org/4.x/index.html).
+
+### Build arguments
+- `LIQUIGRAPH_VERSION` (default: `4.0.2`)
+
+### Configuration: environment variables
+- `CHANGELOG` - path to migration file within the container.
+- `NEO4J_JDBC_URL` - URL for connecting to the database. See [Supported JDBC urls](https://www.liquigraph.org/4.x/index.html#detailed_section).
+- `NEO4J_USER`, `NEO4J_PASSWORD` - authorization credentials.

--- a/liquigraph-ci/README.md
+++ b/liquigraph-ci/README.md
@@ -9,3 +9,8 @@ See section [Highway to shell](https://www.liquigraph.org/4.x/index.html).
 - `CHANGELOG` - path to migration file within the container.
 - `NEO4J_JDBC_URL` - URL for connecting to the database. See [Supported JDBC urls](https://www.liquigraph.org/4.x/index.html#detailed_section).
 - `NEO4J_USER`, `NEO4J_PASSWORD` - authorization credentials.
+
+##### Wait until database becomes available
+- `WAIT_FOR_URL` - URL for testing whether the database is ready (uses `wget`).
+- `WAIT_RETRIES` - maximum retries.
+- `WAIT_BETWEEN` - pause between retries (in seconds).

--- a/liquigraph-ci/wait.sh
+++ b/liquigraph-ci/wait.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+url="$1"
+shift
+max_retries="$1"
+shift
+wait_between="$1"
+shift
+cmd="$@"
+
+retries=0
+until wget --spider -q "$url"; do
+  retries=$((retries + 1))
+  if [ "$retries" -eq "$max_retries" ]
+    then
+      exit 1
+    else
+      >&2 echo "Waiting for $wait_between second(s)"
+      sleep $wait_between
+  fi
+done
+
+>&2 echo "$url is available"
+exec $cmd


### PR DESCRIPTION
# Docker image for `liquigraph-ci`

See section [Highway to shell](https://www.liquigraph.org/4.x/index.html).

### Build arguments
- `LIQUIGRAPH_VERSION` (default: `4.0.2`)

### Configuration: environment variables
- `CHANGELOG` - path to migration file within the container.
- `NEO4J_JDBC_URL` - URL for connecting to the database. See [Supported JDBC urls](https://www.liquigraph.org/4.x/index.html#detailed_section).
- `NEO4J_USER`, `NEO4J_PASSWORD` - authorization credentials.

##### Wait until database becomes available
- `WAIT_FOR_URL` - URL for testing whether the database is ready (uses `wget`).
- `WAIT_RETRIES` - maximum retries.
- `WAIT_BETWEEN` - pause between retries (in seconds).

-----------------------------------

## Security issues
- Using `wget --no-check-certificate`