### PR TITLE
Update Dockerfile

### DIFF
--- a/.github/workflows/sbt-docker-publish.yaml
+++ b/.github/workflows/sbt-docker-publish.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE_NAME: 'grupoabraxas/sbt-docker'
-  IMAGE_TAG: 'latest'
+  IMAGE_TAG: 'jre-19'
 
 jobs:
   publish:

--- a/sbt-docker/Dockerfile
+++ b/sbt-docker/Dockerfile
@@ -1,18 +1,18 @@
-FROM eclipse-temurin:17.0.4_8-jre-alpine
+FROM eclipse-temurin:19.0.1_10-jre-alpine
 
-ENV SBT_VERSION 1.7.1
+RUN apk add --no-cache docker git bash
+
+ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk /tmp/glibc-2.29-r0.apk
+
+RUN apk add --force-overwrite /tmp/glibc-2.29-r0.apk
+RUN apk fix --force-overwrite alpine-baselayout-data
+RUN rm -rf /tmp/*
+
+ENV SBT_VERSION 1.8.2
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
 
-RUN \
-  apk add --no-cache --virtual=.build-dependencies curl bc ca-certificates && \
-  apk add --no-cache bash && \
-  cd /tmp && \
-  curl -fsL https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz | tar xfz - -C /usr/local && \
-  curl -fsL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub > /etc/apk/keys/sgerrand.rsa.pub && \
-  curl -fsL https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk > glibc-2.29-r0.apk && \
-  apk add glibc-2.29-r0.apk && \
-  apk del .build-dependencies && \
-  rm -rf /tmp/*
-
-RUN apk add --no-cache docker git
+ADD https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz /tmp/sbt.tgz
+RUN tar xfz /tmp/sbt.tgz --directory=/usr/local
+RUN rm -rf /tmp/*

--- a/sbt-docker/Dockerfile
+++ b/sbt-docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM eclipse-temurin:17.0.4_8-jre-alpine
 
-ENV SBT_VERSION 1.4.4
+ENV SBT_VERSION 1.7.1
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
 
@@ -15,4 +15,4 @@ RUN \
   apk del .build-dependencies && \
   rm -rf /tmp/*
 
-RUN apk add --no-cache docker
+RUN apk add --no-cache docker git


### PR DESCRIPTION
### Update sbt

New versions of open jdk comming from Temurium inside of adopt jdk https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

Exists a issue with java 16+ and sbt-dotenv, explained [here](https://github.com/Philippus/sbt-dotenv#illegal-reflective-access-warnings). 

But TLDR

just use the latest version of sbt-dotenv

```scala
addSbtPlugin("nl.gn0s1s"        % "sbt-dotenv"          % "3.0.0")
```

And add the file `.jvmopts` side of `build.sbt` wiht this content:
```
--add-opens=java.base/java.util=ALL-UNNAMED
--add-opens=java.base/java.lang=ALL-UNNAMED
```

